### PR TITLE
Escaped carriage returns / new lines

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "properties-reader",
   "description": "Properties file reader for Node.js",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "author": {
     "name": "Steve King",
     "email": "steve@mydev.co"

--- a/src/PropertiesReader.js
+++ b/src/PropertiesReader.js
@@ -96,6 +96,12 @@
         else if (value === 'true' || value === 'false') {
             parsedValue = (value === 'true');
         }
+        else {
+            var replacements = {'\\n': '\n', '\\r': '\r', '\\t': '\t'};
+            parsedValue = value.replace(/\\[nrt]/g, function (key) {
+                return replacements[key];
+            });
+        }
 
         return parsedValue;
     };

--- a/test/readerTest.js
+++ b/test/readerTest.js
@@ -103,5 +103,17 @@ module.exports = new TestCase("Reader", {
       Assertions.assert(app.set.withArgs('properties', properties).calledOnce, 'The complete properties object should be set as "properties"');
       Assertions.assert(app.set.withArgs('some.property', 'Value').calledOnce, 'Sets all properties');
       Assertions.assert(app.set.withArgs('foo.bar', 'A Value').calledOnce, 'Sets all properties');
+   },
+
+   'test Permits escaped new line characters': function () {
+       var properties = givenFilePropertiesReader('\n\nsome.property= Multi\\n Line \\nString \nfoo.bar = A Value');
+
+       // parsed access modifies the new line characters
+       Assertions.assertEquals(properties.get('foo.bar'), 'A Value', 'Sets all properties');
+       Assertions.assertEquals(properties.get('some.property'), 'Multi\n Line \nString', 'Sets all properties');
+
+       // raw access does not modify the new line characters
+       Assertions.assertEquals(properties.getRaw('some.property'), 'Multi\\n Line \\nString', 'Sets all properties');
+       Assertions.assertEquals(properties.path().some.property, 'Multi\\n Line \\nString', 'Sets all properties');
    }
 });


### PR DESCRIPTION
When getting a parsed value from the reader, escaped new line, carriage return and tab characters will be replaced with the actual values. To get the underlying string without parser modifications, use `getRaw` or `path`

Resolves https://github.com/steveukx/properties/issues/3
