### PR TITLE
chore: update mkdirp to support strict mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     }
   ],
   "dependencies": {
-    "mkdirp": "~0.3.5"
+    "mkdirp": "~0.5.1"
   },
   "devDependencies": {
     "unit-test": "*"


### PR DESCRIPTION
Enables the library to run in environments where strict mode is enabled.