### PR TITLE
Create enumerable properties for properties.path()

### DIFF
--- a/src/properties-reader.js
+++ b/src/properties-reader.js
@@ -217,14 +217,14 @@ PropertiesReader.prototype.set = function (key, value) {
       }
 
       if (!has(source, step)) {
-         Object.defineProperty(source, step, { value: {} });
+         Object.defineProperty(source, step, { value: {}, enumerable: true });
       }
 
       source = source[step]
    }
 
    if (expanded[0] === '__proto__') {
-      Object.defineProperty(source, expanded[0], { value: parsedValue });
+      Object.defineProperty(source, expanded[0], { value: parsedValue, enumerable: true });
    }
    else if (typeof parsedValue === 'string' && typeof  source[expanded[0]] === 'object') {
       source[expanded[0]][''] = parsedValue;

--- a/test/reader.spec.js
+++ b/test/reader.spec.js
@@ -105,6 +105,13 @@ describe('Reader', () => {
       expect(properties.path().foo.bar).toBe('A Value');
    });
 
+   it('Property paths are enumerable', async () => {
+      await givenTheProperties('some.property=Value');
+
+      expect(Object.keys(properties.path())).toEqual(['some']);
+      expect(Object.keys(properties.path().some)).toEqual(['property']);
+   });
+
    it('Sets properties into an app', async () => {
       const set = jest.fn();
       (await givenTheProperties(`


### PR DESCRIPTION
The return value of properties.path() had enumerable keys in 2.1.1 and earlier. Starting in 2.2.0, the keys were no longer enumerable as part of the change made for #40 in 0877cc8.

Fixes #58